### PR TITLE
Feature(#3) - Add support for custom company URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-
 `AzurePipeline` is a simple Plugin to view your current Pipeline runs
-
 
 # Description
 
@@ -15,13 +13,14 @@ This product was not developed or approved by Azure
 
 You have to set the following properties
 
- - Company Name
- - Project
- - Access Token (with the following rights)
-   - Build(Read)
-   - Release(Read)
- - Pipeline ID (get it from the URL, called definitionId)
- - run Index -> starting at 0 für the current run up to 30 for the 30th run
+- Company Name
+- Custom URL (optional, default is "https://dev.azure.com/")
+- Project
+- Access Token (with the following rights)
+  - Build(Read)
+  - Release(Read)
+- Pipeline ID (get it from the URL, called definitionId)
+- run Index -> starting at 0 für the current run up to 30 for the 30th run
 
 # Features
 
@@ -31,11 +30,9 @@ You have to set the following properties
 
 ![](screenshot.png)
 
-
 # Installation
 
 In the Release folder, you can find the file `com.buzzet.azurepipeline.streamDeckPlugin`. If you double-click this file on your machine, Stream Deck will install the plugin.
-
 
 # Source code
 

--- a/Sources/com.buzzet.azurepipeline.sdPlugin/index.html
+++ b/Sources/com.buzzet.azurepipeline.sdPlugin/index.html
@@ -26,9 +26,13 @@
 				var company = "";
 				var project = "";
 				var pipelineId = "";
-				
-			    if (settings != null && settings.hasOwnProperty('company')) {
+				var customURL = "https://dev.azure.com/";
+
+				if (settings != null && settings.hasOwnProperty('company')) {
 					company = settings["company"];
+				}
+				if (settings != null && settings.hasOwnProperty('customURL')) {
+					customURL = settings["customURL"];
 				}
 				if (settings != null && settings.hasOwnProperty('project')) {
 					project = settings["project"];
@@ -36,13 +40,14 @@
 				if (settings != null && settings.hasOwnProperty('pipelineId')) {
 					pipelineId = settings["pipelineId"];
 				}
-				this.OpenUrl("https://dev.azure.com/" + company + "/" + project + "/_build?definitionId=" + pipelineId)	
+				this.OpenUrl(customURL + company + "/" + project + "/_build?definitionId=" + pipelineId)	
 			},
 
 			onWillAppear: async function (context, settings, coordinates) {
 				console.log(settings)
 				var company = "";
 				var project = "";
+				var customURL = "https://dev.azure.com/";
 				// var repo = "";
 				var pipelineId = ""
 				var index = 0
@@ -55,6 +60,9 @@
 				}
 				if (settings != null && settings.hasOwnProperty('project')) {
 					project = settings["project"];
+				}
+				if (settings != null && settings.hasOwnProperty('customURL')) {
+					customURL = settings["customURL"];
 				}
 				// if (settings != null && settings.hasOwnProperty('repo')) {
 				// 	repo = settings["repo"];
@@ -76,11 +84,11 @@
 				}
 				headers.append('Authorization', 'Basic' + btoa("abc" + ":" + accessToken))
 				console.log(settings)
-				console.log(company, project, pipelineId, index)
+				console.log(company, customURL, project, pipelineId, index)
 				while (true) {
 
 
-					fetch("http://dev.azure.com/" + company + "/" + project + "/_apis/pipelines/" + pipelineId + "/runs?api-version=6.0-preview.1", { method: 'GET', headers: headers }).then((response) => {
+					fetch(customURL + company + "/" + project + "/_apis/pipelines/" + pipelineId + "/runs?api-version=6.0-preview.1", { method: 'GET', headers: headers }).then((response) => {
 						return response.json()
 					}).then((data) => {
 						let value = data.value;
@@ -215,6 +223,11 @@
 
 						var newValue = jsonPayload.setCompany;
 						settingsCache['company'] = newValue
+					}
+					if (jsonPayload.hasOwnProperty('setCustomURL')) {
+
+						var newValue = jsonPayload.setCustomURL;
+						settingsCache['customURL'] = newValue
 					}
 					if (jsonPayload.hasOwnProperty('setProject')) {
 

--- a/Sources/com.buzzet.azurepipeline.sdPlugin/manifest.json
+++ b/Sources/com.buzzet.azurepipeline.sdPlugin/manifest.json
@@ -23,7 +23,7 @@
   "Icon": "keyIcon",
   "URL": "https://github.com/Buzzet/streamdeck-azure-pipeline",
   "PropertyInspectorPath": "shellyControll.html",
-  "Version": "1.1",
+  "Version": "1.2",
   "OS": [
     {
       "Platform": "mac",

--- a/Sources/com.buzzet.azurepipeline.sdPlugin/shellyControll.html
+++ b/Sources/com.buzzet.azurepipeline.sdPlugin/shellyControll.html
@@ -17,6 +17,12 @@
             </div>
         </div>
         <div type="field" class="sdpi-item">
+            <div class="sdpi-item-label">Custom URL</div>
+            <div class="sdpi-item-value field">
+                <input id="customURLField" oninput="sendValueToPlugin(event.target.value, 'setCustomURL')">
+            </div>
+        </div>
+        <div type="field" class="sdpi-item">
             <div class="sdpi-item-label">Project</div>
             <div class="sdpi-item-value field">
                 <input id="projectField" oninput="sendValueToPlugin(event.target.value, 'setProject')">
@@ -57,6 +63,7 @@
                 }
                 settings = jsonObj.actionInfo.payload.settings;
                 document.getElementById('companyField').value = settings.company || ''
+                document.getElementById('customURLField').value = settings.customURL || ''
                 document.getElementById('projectField').value = settings.project || ''
                 document.getElementById('accessTokenField').value = settings.accessToken || ''
                 document.getElementById('pipelineIdField').value = settings.pipelineId || ''
@@ -74,7 +81,6 @@
                 $SD.api.sendToPlugin(uuid, pluginAction, payload);
             }
         }
-
     </script>
 
 </body>


### PR DESCRIPTION
This PR adds a customURL option for support of self-hosted Azure DevOps servers
(Please note this doesn't contain the updated .streamDeckPlugin build)